### PR TITLE
Add explicit dependency on guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
     </properties>
 
     <dependencies>
+
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>18.0</version>
+			</dependency>
+
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>protege-client</artifactId>


### PR DESCRIPTION
we are using guava in this project so we should depend on it. Previously, we
relied on a transitive dependency satisfying this, but this is fragile.